### PR TITLE
Add Flask-based web interface for cartogram generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Cartogram Tool
+
+This repository contains a TopoJSON file of U.S. states (`us.json`) and a
+utility script to generate contiguous cartograms from arbitrary state data.
+
+## Requirements
+
+```
+pip install cartogram geopandas topojson pandas Flask
+```
+
+## Usage
+
+Prepare a CSV file with FIPS codes and a numeric value for each state. The CSV
+must contain at least two columns named `id` and `value`:
+
+```
+id,value
+1,10.2
+2,5.4
+...
+```
+
+Run the script to produce a GeoJSON cartogram:
+
+```
+python3 generate_cartogram.py us.json data.csv -o output.geojson
+```
+
+The resulting `output.geojson` contains transformed geometries which can be
+visualized with standard GIS tools.
+
+## Web Application
+
+A simple Flask app is included to run the cartogram generator via your browser.
+
+Start the server:
+
+```
+python3 app.py
+```
+
+Open [http://localhost:5000](http://localhost:5000) and upload a CSV file with
+`id` and `value` columns. The generated GeoJSON will be downloaded
+automatically.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import tempfile
+
+from flask import Flask, request, send_file
+
+from generate_cartogram import generate_cartogram
+
+app = Flask(__name__)
+
+HTML_FORM = """
+<!doctype html>
+<title>Cartogram Generator</title>
+<h1>Upload CSV Data</h1>
+<form method="post" enctype="multipart/form-data">
+  <input type="file" name="csv" accept="text/csv" required><br>
+  Iterations: <input type="number" name="iterations" value="5" min="1"><br>
+  <input type="submit" value="Generate">
+</form>
+"""
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    if request.method == "POST":
+        file = request.files.get("csv")
+        if not file:
+            return HTML_FORM, 400
+        with tempfile.NamedTemporaryFile(suffix=".csv") as csv_tmp, tempfile.NamedTemporaryFile(suffix=".geojson", delete=False) as out_tmp:
+            file.save(csv_tmp.name)
+            iterations = int(request.form.get("iterations", 5))
+            generate_cartogram("us.json", csv_tmp.name, out_tmp.name, iterations)
+            return send_file(out_tmp.name, as_attachment=True, download_name="cartogram.geojson")
+    return HTML_FORM
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/generate_cartogram.py
+++ b/generate_cartogram.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Generate a contiguous cartogram from a TopoJSON and CSV state data.
+
+The script expects a TopoJSON file with US state geometries (such as the
+`us.json` file in this repository) and a CSV file containing at least two
+columns: `id` (FIPS code matching the TopoJSON `id`) and `value` which
+is the numeric value used to scale states in the cartogram.
+
+Example usage:
+    python3 generate_cartogram.py us.json data.csv -o cartogram.geojson
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import geopandas as gpd
+import pandas as pd
+from cartogram import cartogram as cg
+from topojson import Topology
+
+
+def load_states(topojson_path: str) -> gpd.GeoDataFrame:
+    """Load US states from a TopoJSON file as a GeoDataFrame with an `id` column."""
+    with open(topojson_path) as f:
+        topo_data = json.load(f)
+    topo = Topology(topo_data, object_name="states")
+    features = json.loads(topo.to_geojson())['features']
+
+    for f in features:
+        # Preserve the feature id so it can be merged with the CSV data
+        f.setdefault('properties', {})['id'] = f['id']
+    return gpd.GeoDataFrame.from_features(features)
+
+
+def generate_cartogram(
+    topojson_path: str,
+    csv_path: str,
+    output_path: str = "cartogram.geojson",
+    iterations: int = 5,
+) -> str:
+    """Generate a GeoJSON cartogram from ``csv_path``.
+
+    Parameters
+    ----------
+    topojson_path:
+        Path to a TopoJSON file with U.S. state geometries.
+    csv_path:
+        CSV file containing ``id`` and ``value`` columns.
+    output_path:
+        Where to write the resulting GeoJSON file.
+    iterations:
+        Number of cartogram iterations to perform.
+
+    Returns
+    -------
+    str
+        The path to the written GeoJSON file.
+    """
+    states = load_states(topojson_path)
+    data = pd.read_csv(csv_path)
+    if "id" not in data.columns or "value" not in data.columns:
+        sys.exit("CSV file must contain 'id' and 'value' columns")
+    data["id"] = data["id"].astype(int)
+
+    merged = states.merge(data, on="id", how="left")
+    if merged["value"].isna().any():
+        missing = merged[merged["value"].isna()]["id"].tolist()
+        sys.exit(f"Missing value for state ids: {missing}")
+
+    carto = cg.Cartogram(
+        merged,
+        "value",
+        max_iterations=iterations,
+        verbose=True,
+    )
+    carto.to_file(output_path, driver="GeoJSON")
+    return output_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate contiguous cartogram")
+    parser.add_argument("topojson", help="Input TopoJSON file with state shapes")
+    parser.add_argument("csv", help="CSV containing columns 'id' and 'value'")
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="cartogram.geojson",
+        help="Output GeoJSON path (default: cartogram.geojson)",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=5,
+        help="Number of cartogram iterations (default: 5)",
+    )
+    args = parser.parse_args()
+
+    output = generate_cartogram(
+        args.topojson, args.csv, output_path=args.output, iterations=args.iterations
+    )
+    print(f"Cartogram written to {output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `generate_cartogram` function for reuse
- create `app.py` Flask app to upload CSV and download GeoJSON
- document web app usage in README

## Testing
- `python3 -m py_compile generate_cartogram.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6844b1eb165c832782805042e1caed55