### PR TITLE
Add Flask web app to generate cartograms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ utility script to generate contiguous cartograms from arbitrary state data.
 ## Requirements
 
 ```
-pip install cartogram geopandas topojson pandas
+pip install -r requirements.txt
 ```
 
 ## Usage
@@ -29,3 +29,14 @@ python3 generate_cartogram.py us.json data.csv -o output.geojson
 
 The resulting `output.geojson` contains transformed geometries which can be
 visualized with standard GIS tools.
+
+## Web Application
+
+Run a small Flask server to generate cartograms directly in the browser:
+
+```
+python3 app.py
+```
+
+Navigate to `http://localhost:5000` and upload a CSV file with `id` and `value`
+columns to see the resulting cartogram rendered with D3.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+import tempfile
+
+from flask import Flask, request, Response
+
+from generate_cartogram import generate_cartogram_df
+
+app = Flask(__name__, static_folder=".", static_url_path="")
+
+
+@app.route("/")
+def index() -> Response:
+    return app.send_static_file("index.html")
+
+
+@app.route("/cartogram", methods=["POST"])
+def cartogram_route() -> Response:
+    if "file" not in request.files:
+        return Response("Missing CSV file", status=400)
+    file = request.files["file"]
+    iterations = int(request.form.get("iterations", 5))
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".csv") as tmp:
+        file.save(tmp.name)
+        tmp_path = tmp.name
+    try:
+        carto = generate_cartogram_df("us.json", tmp_path, iterations)
+        geojson = carto.to_json()
+    except Exception as exc:
+        os.remove(tmp_path)
+        return Response(str(exc), status=400)
+    os.remove(tmp_path)
+    return Response(geojson, content_type="application/json")
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/index.html
+++ b/index.html
@@ -1,64 +1,50 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Non-Contiguous Cartogram</title>
+<title>Cartogram Generator</title>
 <style>
-
-.land {
-  fill: #fff;
-  stroke: #ccc;
-}
-
-.state {
-  fill: #ccc;
-  stroke: #666;
-}
-
+body { font-family: sans-serif; }
+#controls { margin: 1em 0; }
+.land { fill: #eee; stroke: #999; }
+.state { fill: steelblue; stroke: #fff; }
 </style>
-<body>
-<script src="//d3js.org/d3.v3.min.js"></script>
-<script src="//d3js.org/topojson.v1.min.js"></script>
+<div id="controls">
+  <input type="file" id="csv" accept=".csv" />
+  <button id="generate">Generate Cartogram</button>
+</div>
+<svg width="960" height="600"></svg>
+<script src="https://d3js.org/d3.v7.min.js"></script>
+<script src="https://unpkg.com/topojson-client@3"></script>
 <script>
+const svg = d3.select("svg");
+const path = d3.geoPath().projection(d3.geoAlbersUsa().scale(1000).translate([480,300]));
+let baseStates;
 
-// Ratio of Obese (BMI >= 30) in U.S. Adults, CDC 2008
-var valueById = [
-   NaN, .187, .198,  NaN, .133, .175, .151,  NaN, .100, .125,
-  .171,  NaN, .172, .133,  NaN, .108, .142, .167, .201, .175,
-  .159, .169, .177, .141, .163, .117, .182, .153, .195, .189,
-  .134, .163, .133, .151, .145, .130, .139, .169, .164, .175,
-  .135, .152, .169,  NaN, .132, .167, .139, .184, .159, .140,
-  .146, .157,  NaN, .139, .183, .160, .143
-];
-
-var path = d3.geo.path();
-
-var svg = d3.select("body").append("svg")
-    .attr("width", 960)
-    .attr("height", 500);
-
-d3.json("us.json", function(error, us) {
-  if (error) throw error;
-
-  svg.append("path")
-      .datum(topojson.feature(us, us.objects.land))
-      .attr("class", "land")
-      .attr("d", path);
-
-  svg.selectAll(".state")
-      .data(topojson.feature(us, us.objects.states).features)
-    .enter().append("path")
-      .attr("class", "state")
-      .attr("d", path)
-      .attr("transform", function(d) {
-        var centroid = path.centroid(d),
-            x = centroid[0],
-            y = centroid[1];
-        return "translate(" + x + "," + y + ")"
-            + "scale(" + Math.sqrt(valueById[d.id] * 5 || 0) + ")"
-            + "translate(" + -x + "," + -y + ")";
-      })
-      .style("stroke-width", function(d) {
-        return 1 / Math.sqrt(valueById[d.id] * 5 || 1);
-      });
+d3.json("us.json").then(us => {
+  baseStates = topojson.feature(us, us.objects.states).features;
+  svg.append("g").attr("id","states")
+     .selectAll("path")
+     .data(baseStates)
+     .enter().append("path")
+     .attr("class","state")
+     .attr("d", path);
 });
 
+document.getElementById('generate').addEventListener('click', () => {
+  const file = document.getElementById('csv').files[0];
+  if (!file) { alert('Please choose a CSV file.'); return; }
+  const formData = new FormData();
+  formData.append('file', file);
+  fetch('/cartogram', { method: 'POST', body: formData })
+    .then(r => {
+      if (!r.ok) throw new Error('Error generating cartogram');
+      return r.json();
+    })
+    .then(geojson => {
+      svg.select('#states').selectAll('path')
+        .data(geojson.features, d => d.properties.id)
+        .transition().duration(750)
+        .attr('d', path);
+    })
+    .catch(err => alert(err));
+});
 </script>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+cartogram
+geopandas
+pandas
+topojson


### PR DESCRIPTION
## Summary
- add a Flask server with endpoint to produce cartogram GeoJSON
- expose a helper function `generate_cartogram_df`
- create a simple HTML interface that uploads a CSV and displays the cartogram via D3
- document new usage and dependencies

## Testing
- `python -m py_compile generate_cartogram.py app.py`
- `python app.py` *(started server successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6844b9f1cae88327925fbea3e0260774