### PR TITLE
Fix cartogram redraws

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -5,3 +5,4 @@ Use this file to record summaries of each task or idea for future agents.
 - Added an iteration selector and shared cartogram request helper on the web UI, fixing the tooltip's hidden state.
 - Added static cartogram files for presets and updated the UI to load them (with a GitHub Pages warning), so preset selection no longer triggers server errors.
 - Allow generating cartograms directly from selected presets when no CSV is provided, improving GitHub Pages usability.
+- Fixed cartogram redraws by keying states by id and syncing tooltip lookup to GeoJSON properties.

--- a/index.html
+++ b/index.html
@@ -53,9 +53,13 @@ Promise.all([
   stateNames = names;
   presets = presetData;
   baseStates = topojson.feature(us, us.objects.states).features;
+  baseStates.forEach(f => {
+    f.properties = f.properties || {};
+    f.properties.id = f.properties.id ?? f.id;
+  });
   const stateGroup = svg.append('g').attr('id','states')
     .selectAll('path')
-    .data(baseStates)
+    .data(baseStates, d => d.properties.id)
     .enter().append('path')
     .attr('class','state')
     .attr('d', path)
@@ -73,11 +77,23 @@ Promise.all([
 
 
 function renderCartogram(geojson) {
-  svg.select('#states').selectAll('path')
-    .data(geojson.features, d => d.properties.id)
+  const states = svg.select('#states').selectAll('path')
+    .data(geojson.features, d => d.properties?.id ?? d.id);
+
+  states.enter()
+    .append('path')
+    .attr('class','state')
+    .on('click', (event, d) => showTooltip(event, d))
+    .merge(states)
     .transition().duration(750)
     .attr('d', path);
-  geojson.features.forEach(f => currentValues[f.properties.id] = f.properties.value);
+
+  states.exit().remove();
+
+  geojson.features.forEach(f => {
+    const id = f.properties?.id ?? f.id;
+    currentValues[id] = f.properties?.value;
+  });
 }
 
 function requestCartogram(formData) {
@@ -140,8 +156,9 @@ document.getElementById('preset-select').addEventListener('change', ev => {
 });
 
 function showTooltip(event, d) {
-  const value = currentValues[d.id] ?? 'N/A';
-  const name = stateNames[d.id] || d.id;
+  const featureId = d.properties?.id ?? d.id;
+  const value = currentValues[featureId] ?? 'N/A';
+  const name = stateNames[featureId] || featureId;
   tooltip.style('left', (event.pageX + 5) + 'px')
          .style('top', (event.pageY + 5) + 'px')
          .style('display', 'block')


### PR DESCRIPTION
## Summary
- ensure base state features expose id properties for stable bindings
- rework cartogram rendering to join on state ids, handle enter/exit, and update tooltip lookups

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f206463888327b0c5b68bfe7c3943)